### PR TITLE
[기능] MEMBER -> SELLER 권한 신청하는 부분에 권한 승인 로직까지 임시로 추가함.

### DIFF
--- a/src/main/java/com/juno/appling/domain/entity/member/Member.java
+++ b/src/main/java/com/juno/appling/domain/entity/member/Member.java
@@ -56,4 +56,8 @@ public class Member {
         return new Member(joinDto.getEmail(), joinDto.getPassword(), joinDto.getNickname(), joinDto.getName(), joinDto.getBirth(), Role.MEMBER, null, null, now, now);
     }
 
+    public void patchMemberRole(Role role){
+        this.role = role;
+    }
+
 }

--- a/src/main/java/com/juno/appling/domain/entity/member/MemberApplySeller.java
+++ b/src/main/java/com/juno/appling/domain/entity/member/MemberApplySeller.java
@@ -37,4 +37,8 @@ public class MemberApplySeller {
         LocalDateTime now = LocalDateTime.now();
         return new MemberApplySeller(memberId, MemberApplySellerStatus.APPLY, now, now);
     }
+
+    public void patchApplyStatus(MemberApplySellerStatus status){
+        this.status = status;
+    }
 }

--- a/src/main/java/com/juno/appling/service/member/MemberService.java
+++ b/src/main/java/com/juno/appling/service/member/MemberService.java
@@ -3,6 +3,8 @@ package com.juno.appling.service.member;
 import com.juno.appling.common.security.TokenProvider;
 import com.juno.appling.domain.entity.member.Member;
 import com.juno.appling.domain.entity.member.MemberApplySeller;
+import com.juno.appling.domain.enums.member.MemberApplySellerStatus;
+import com.juno.appling.domain.enums.member.Role;
 import com.juno.appling.domain.vo.MessageVo;
 import com.juno.appling.domain.vo.member.MemberVo;
 import com.juno.appling.repository.member.MemberApplySellerRepository;
@@ -58,10 +60,21 @@ public class MemberService {
         String token = resolveToken(request);
         Long memberId = tokenProvider.getMemberId(token);
 
-        memberApplySellerRepository.save(MemberApplySeller.of(memberId));
+        MemberApplySeller saveMemberApply = memberApplySellerRepository.save(MemberApplySeller.of(memberId));
+
+        // TODO 임시로 판매자 권인 승인하도록 로직을 만들어둠 나중에는 admin에서 승인해주어야 함
+        permitSeller(memberId, saveMemberApply);
 
         return MessageVo.builder()
-                .message("성공")
+                .message("임시적으로 SELLER 즉시 승인")
                 .build();
+    }
+
+    private void permitSeller(Long memberId, MemberApplySeller saveMemberApply) {
+        saveMemberApply.patchApplyStatus(MemberApplySellerStatus.PERMIT);
+        Member member = memberRepository.findById(memberId).orElseThrow(() ->
+                new IllegalArgumentException("존재하지 않는 회원입니다.")
+        );
+        member.patchMemberRole(Role.SELLER);
     }
 }


### PR DESCRIPTION
<상세>

이유는 아직 Admin 화면이 없어 해당 승인을 해줄수 있는 기능이 없기 때문에 요청이 들어오면 바로 승인 로직을 태움.

나중에 로직이 분리될 것을 생각하여 다른 메서드로 분리해둠